### PR TITLE
Regulate emulator speed

### DIFF
--- a/Astro8-Emulator/main.cpp
+++ b/Astro8-Emulator/main.cpp
@@ -464,7 +464,7 @@ bool Update(double deltatime)
 			memoryIndex = programCounter;
 			// RM
 			// IW
-			InstructionReg = memoryBytes.at(clamp(memoryIndex, 0, 65534));
+			InstructionReg = memoryBytes[clamp(memoryIndex, 0, 65534)];
 			// CE
 			programCounter = clamp(programCounter + 1, 0, 65534);
 			step = 1;
@@ -473,7 +473,7 @@ bool Update(double deltatime)
 
 		// Address in microcode ROM
 		int microcodeLocation = (BitRange((unsigned)InstructionReg, 11, 5) * 64) + (step * 4) + (flags[0] * 2) + flags[1];
-		MicroInstruction mcode = microinstructionData.at(microcodeLocation);
+		MicroInstruction mcode = microinstructionData[microcodeLocation];
 
 
 		// Check for any reads and execute if applicable
@@ -490,7 +490,7 @@ bool Update(double deltatime)
 			bus = CReg;
 			break;
 		case READ_RM:
-			bus = memoryBytes.at(clamp(memoryIndex, 0, 65534));
+			bus = memoryBytes[clamp(memoryIndex, 0, 65534)];
 			break;
 		case READ_IR:
 			bus = BitRange(InstructionReg, 0, 11);
@@ -588,7 +588,7 @@ bool Update(double deltatime)
 			InstructionReg = bus;
 			break;
 		case WRITE_WM:
-			memoryBytes.at(clamp(memoryIndex, 0, 65534)) = bus;
+			memoryBytes[clamp(memoryIndex, 0, 65534)] = bus;
 			break;
 		case WRITE_J:
 			programCounter = clamp(bus, 0, 65534); 
@@ -605,10 +605,10 @@ bool Update(double deltatime)
 		// Display current pixel
 		if (iterations % frameSpeed == 0)
 		{
-			int characterRamValue = memoryBytes.at(clamp(characterRamIndex + 16382, 0, 65534));
-			bool charPixRomVal = characterRom.at((characterRamValue * 64) + (charPixY * 8) + charPixX);
+			int characterRamValue = memoryBytes[clamp(characterRamIndex + 16382, 0, 65534)];
+			bool charPixRomVal = characterRom[(characterRamValue * 64) + (charPixY * 8) + charPixX];
 
-			int pixelVal = memoryBytes.at(clamp(pixelRamIndex, 0, 65534));
+			int pixelVal = memoryBytes[clamp(pixelRamIndex, 0, 65534)];
 			int r, g, b;
 
 			if (charPixRomVal == true && imgX < 60) {


### PR DESCRIPTION
Addresses #26 and #11

A few optimizations in 645b9b62c86f0753f35d54888a40c74fe50cc470, 152157788b369aab0d39a28e5ee4ed56123878e1, and d63386b066e5b1ebe0aa895ecd7c41992e81e00a.

In 486d86273d1557718f681bd7e4bd62397e8d7833, drawing is separated from update. Chrono is used in the main loop to regularly call to update and draw.