### PR TITLE
Adding proper examples for BNKC and JDWB

### DIFF
--- a/docs/Architecture/Instruction Set.md
+++ b/docs/Architecture/Instruction Set.md
@@ -521,7 +521,8 @@ in register **C**
 #### Syntax
 
 ```
-BNK 1
+LDIC 15
+BNKC    , Sets the memory bank register to 0b1111
 ```
 
 <br>
@@ -536,7 +537,8 @@ register **B** and advance program counter by 2
 #### Syntax
 
 ```
-BNK 1
+LDWB
+HERE <Value>
 ```
 
 <br>

--- a/docs/Architecture/Instruction Set.md
+++ b/docs/Architecture/Instruction Set.md
@@ -521,8 +521,9 @@ in register **C**
 #### Syntax
 
 ```
-LDIC 15
-BNKC    , Sets the memory bank register to 0b1111
+LDIA 15  , Load 15 into A then swap it into C
+SWPC
+BNKC     , Sets the memory bank register to C, which is 15
 ```
 
 <br>


### PR DESCRIPTION
After reading the Documentation I've found out that the last 2 instructions' examples where wrong and using the same as `BNK`. This replaces the wrong examples by examples for those instructions.